### PR TITLE
Added check to make sure JQuery is available for tests

### DIFF
--- a/src/testmanager.coffee
+++ b/src/testmanager.coffee
@@ -106,6 +106,7 @@ class TestManager extends EventEmitter
             display: none;
           }
         </style>
+        <script>window.jQuery || document.write('<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"><\/script>')</script>
         <script src="//code.jquery.com/qunit/qunit-1.16.0.js"></script>
         <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.16.0.css">
         <link rel="stylesheet" href="//code.jquery.com/ui/1.11.2/themes/smoothness/jquery-ui.css">


### PR DESCRIPTION
This came up when trying to write tests for an email, which shouldn't include any javascript. I added a line of code that checks if jQuery exists and if it doesn't then it adds jQuery.
